### PR TITLE
Increase memory to avoid "insufficient memory remaining for heap"

### DIFF
--- a/sample-service/manifest.yml
+++ b/sample-service/manifest.yml
@@ -1,7 +1,7 @@
 ---
 applications:
 - name: hello-service
-  memory: 256M
+  memory: 768M
   instances: 1
   buildpack: java_buildpack_offline
   path: target/sample-service-1.1.0.jar


### PR DESCRIPTION
When attempting a `cf push` on this it produced:

```
[APP/PROC/WEB/0] ERR Cannot calculate JVM memory configuration: 
There is insufficient memory remaining for heap. 
Memory available for allocation 256M is less than allocated memory 602436K 
(-XX:ReservedCodeCacheSize=240M, -XX:MaxDirectMemorySize=10M, 
-XX:MaxMetaspaceSize=90436K, -Xss1M * 250 threads)
```